### PR TITLE
Makefile not compatible with POSIX /bin/sh

### DIFF
--- a/oefenzittingen/Makefile
+++ b/oefenzittingen/Makefile
@@ -1,4 +1,5 @@
 .PHONY: opgaven
+number ?= 1
 
 all:
 	make opgaven
@@ -8,8 +9,10 @@ opgaven:
 	$(MAKE) -C opgaven
 
 oplossingen:
-	number=1 ; while [[ $$number -le 17 ]] ; do \
+	number=$(number); \
+	while [ $${number} -le 17 ] ; do \
 		bash makeOplossing.sh $$number; \
-        ((number = number + 1)) ; \
-    done
+		number=`expr $$number + 1`; \
+	done
+	true
 	pdfunite opgaven/opgaven_oefenzittingen.pdf oplossing_*.pdf oplossingen_door_assistenten.pdf oefenzittingen.pdf


### PR DESCRIPTION
The oefenzittingen makefile is now compatible with linux installations that use a POSIX /bin/sh instead of /bin/bash
